### PR TITLE
Added the namespace parameter to AuditSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Added NameSpace parameter to AuditSetting [#8](https://github.com/jcwalker/AuditSystemDsc/issues/8)
+
 ## 1.0.0
 
 * Initial release with DSC Resource AuditSetting

--- a/DSCResources/AuditSetting/AuditSetting.psm1
+++ b/DSCResources/AuditSetting/AuditSetting.psm1
@@ -52,7 +52,7 @@ function Get-TargetResource
 
     $cimInstanceParameters = @{
         Query = $Query
-        ErrorAction = 'Stop'
+        ErrorAction = 'Continue'
     }
 
     if ($PSBoundParameters.ContainsKey('NameSpace'))
@@ -60,7 +60,7 @@ function Get-TargetResource
         $cimInstanceParameters.Add('NameSpace',$NameSpace)
     }
 
-    $queryResult = Get-CimInstance -Query $Query
+    $queryResult = Get-CimInstance @cimInstanceParameters
 
     return @{
         Query = $Query

--- a/DSCResources/AuditSetting/AuditSetting.psm1
+++ b/DSCResources/AuditSetting/AuditSetting.psm1
@@ -20,6 +20,8 @@ $script:localizedData = Get-LocalizedData -ResourceName 'AuditSetting'
     .PARAMETER DesiredValue
         Specifies the desired value of the property being audited.
         Not used in Get-TargetResource.
+    .PARAMETER NameSpace
+        Specifies the namespace of the CIM class.
 #>
 function Get-TargetResource
 {
@@ -41,8 +43,22 @@ function Get-TargetResource
 
         [Parameter(Mandatory=$true)]
         [string]
-        $DesiredValue
+        $DesiredValue,
+
+        [Parameter()]
+        [System.String]
+        $NameSpace
     )
+
+    $cimInstanceParameters = @{
+        Query = $Query
+        ErrorAction = 'Stop'
+    }
+
+    if ($PSBoundParameters.ContainsKey('NameSpace'))
+    {
+        $cimInstanceParameters.Add('NameSpace',$NameSpace)
+    }
 
     $queryResult = Get-CimInstance -Query $Query
 
@@ -50,6 +66,7 @@ function Get-TargetResource
         Query = $Query
         Property = $Property
         Operator = $Operator
+        NameSpace = $NameSpace
         DesiredValue = $DesiredValue
         ResultString = [string[]]$(Write-PropertyValue -Object $queryResult)
     }
@@ -78,7 +95,11 @@ function Set-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $DesiredValue
+        $DesiredValue,
+
+        [Parameter()]
+        [System.String]
+        $NameSpace
     )
 }
 
@@ -93,6 +114,8 @@ function Set-TargetResource
         The comparison operator used to craft the condition that defines compliance.
     .PARAMETER DesiredValue
         Specifies the desired value of the property being audited.
+    .PARAMETER NameSpace
+        Specifies the namespace of the CIM class.
 #>
 function Test-TargetResource
 {
@@ -114,13 +137,27 @@ function Test-TargetResource
 
         [Parameter(Mandatory=$true)]
         [string]
-        $DesiredValue
+        $DesiredValue,
+
+        [Parameter()]
+        [System.String]
+        $NameSpace
     )
 
     try
     {
         $result = $true
-        $queryResult = Get-CimInstance -Query $Query -ErrorAction Stop
+        $cimInstanceParameters = @{
+            Query = $Query
+            ErrorAction = 'Stop'
+        }
+
+        if ($PSBoundParameters.ContainsKey('NameSpace'))
+        {
+            $cimInstanceParameters.Add('NameSpace',$NameSpace)
+        }
+
+        $queryResult = Get-CimInstance @cimInstanceParameters
 
         foreach ($instance in $queryResult)
         {

--- a/DSCResources/AuditSetting/AuditSetting.schema.mof
+++ b/DSCResources/AuditSetting/AuditSetting.schema.mof
@@ -5,5 +5,6 @@ class AuditSetting : OMI_BaseResource
     [Key, Description("The property name to be audited.")] String Property;
     [Key, Description("Specifies the desired value of the property being audited.")] String DesiredValue;
     [Required, Description("The comparison operator to be used to craft the condition that defines compliance.")] String Operator;
+    [Write, Description("Specifies the namespace of the CIM class.")] String NameSpace;
     [Read, Description("An array of strings listing all the properties and values of the WMI class being queried.")] String ResultString[];
 };

--- a/Examples/Resources/AuditSetting/3-AuditSetting_VerifyNetworkPrefixLength.ps1
+++ b/Examples/Resources/AuditSetting/3-AuditSetting_VerifyNetworkPrefixLength.ps1
@@ -1,0 +1,40 @@
+<#PSScriptInfo
+.VERSION 1.0.0
+.GUID ac6e5b9b-c16b-46c6-a3ba-172da1b4a212
+.AUTHOR Jason Walker
+.COMPANYNAME
+.COPYRIGHT
+.TAGS DSCConfiguration
+.LICENSEURI https://github.com/jcwalker/AuditSystemDsc/blob/dev/LICENSE
+.PROJECTURI https://github.com/jcwalker/AuditSystemDsc/
+.ICONURI
+.EXTERNALMODULEDEPENDENCIES
+.REQUIREDSCRIPTS
+.EXTERNALSCRIPTDEPENDENCIES
+.RELEASENOTES
+First version
+#>
+
+<#
+.DESCRIPTION
+ This examples shows how to verify all local users require a password.
+#>
+
+#Requires -Module AuditSystemDsc
+
+configuration AuditSetting_VerifyNetworkPrefixLength
+{
+    Import-DscResource -ModuleName AuditSystemDsc
+
+    node localhost
+    {
+        AuditSetting LocalAccountWithoutPassword
+        {
+            NameSpace = 'ROOT/StandardCimv2'
+            Query = "SELECT * FROM MSFT_NetIPAddress WHERE InterfaceAlias='Ethernet'"
+            Property = "PrefixLength"
+            DesiredValue = '24'
+            Operator = '-eq'
+        }
+    }
+}

--- a/Examples/Resources/AuditSetting/3-AuditSetting_VerifyNetworkPrefixLength.ps1
+++ b/Examples/Resources/AuditSetting/3-AuditSetting_VerifyNetworkPrefixLength.ps1
@@ -28,7 +28,7 @@ configuration AuditSetting_VerifyNetworkPrefixLength
 
     node localhost
     {
-        AuditSetting LocalAccountWithoutPassword
+        AuditSetting VerifyNetworkPrefixLength
         {
             NameSpace = 'ROOT/StandardCimv2'
             Query = "SELECT * FROM MSFT_NetIPAddress WHERE InterfaceAlias='Ethernet'"

--- a/Tests/Integration/AuditSetting.config.ps1
+++ b/Tests/Integration/AuditSetting.config.ps1
@@ -29,5 +29,14 @@ Configuration AuditSetting_AuditNtfsVolumne_Config
             DesiredValue = 'NTFS'
             Operator = '-eq'
         }
+
+        AuditSetting LocalAccountWithoutPassword
+        {
+            NameSpace = 'ROOT/StandardCimv2'
+            Query = "SELECT * FROM MSFT_NetIPAddress WHERE InterfaceAlias='Ethernet'"
+            Property = "PrefixLength"
+            DesiredValue = '24'
+            Operator = '-eq'
+        }
     }
 }

--- a/Tests/Unit/AuditSystem.tests.ps1
+++ b/Tests/Unit/AuditSystem.tests.ps1
@@ -38,6 +38,7 @@ try
                     Property = 'Property1'
                     DesiredValue = 'InDesiredState'
                     Operator = '-eq'
+                    NameSpace = 'root/CIMv2'
                 }
             }
 
@@ -62,6 +63,7 @@ try
                     Property = 'Property1'
                     DesiredValue = 'InDesiredState'
                     Operator = '-eq'
+                    NameSpace = 'root/CIMv2'
                 }
             }
 


### PR DESCRIPTION
Added the namespace parameter to AuditSystem to allow querying cim classes not in the root/cimV2 namespace

fixes #8 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jcwalker/auditsystemdsc/7)
<!-- Reviewable:end -->
